### PR TITLE
GetDirectoryName fixed for path with no slash

### DIFF
--- a/System.IO.FileSystem/Path.cs
+++ b/System.IO.FileSystem/Path.cs
@@ -139,6 +139,9 @@ namespace System.IO
 
                     var lastPathPostion = path.LastIndexOf(DirectorySeparatorChar);
 
+                    if (lastPathPostion == -1)
+                        return string.Empty;
+
                     return path.Substring(0, lastPathPostion);
                 }
             }

--- a/System.IO.FileSystem/Path.cs
+++ b/System.IO.FileSystem/Path.cs
@@ -140,7 +140,9 @@ namespace System.IO
                     var lastPathPostion = path.LastIndexOf(DirectorySeparatorChar);
 
                     if (lastPathPostion == -1)
+                    {
                         return string.Empty;
+                    }
 
                     return path.Substring(0, lastPathPostion);
                 }


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
I have fixed the bug, when the -1 returned from method LastIndexOf() was a second parameter of method Substring, which obviosuly gave an error.
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
I have checked the proposed change of behaviour with original C# and it seems to work as I propose.
Please check my snippet here: https://dotnetfiddle.net/ZuRy2E

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

By the way:
Link https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md is not working for me (firefox).