### PR TITLE
Several fixes for `Path`

### DIFF
--- a/System.IO.FileSystem.UnitTests/PathUnitTests.cs
+++ b/System.IO.FileSystem.UnitTests/PathUnitTests.cs
@@ -5,8 +5,6 @@ namespace System.IO.FileSystem.UnitTests
     [TestClass]
     internal class PathUnitTests
     {
-        private string RootDirectory => "\\";
-
         [TestMethod]
         public void ChangeExtension_adds_extension()
         {
@@ -318,21 +316,21 @@ namespace System.IO.FileSystem.UnitTests
         {
             string fullPath = Path.GetFullPath(@"dir1\dir2\file.ext");
 
-            Assert.AreEqual(RootDirectory + @"\dir1\dir2\file.ext", fullPath);
+            Assert.AreEqual(@"\dir1\dir2\file.ext", fullPath);
          }
 
         [TestMethod]
         public void GetFullPath1()
         {
-            string fullPath = Path.GetFullPath(RootDirectory + @"\dir1\dir2\file.ext");
-            Assert.AreEqual(RootDirectory + @"\dir1\dir2\file.ext", fullPath);
+            string fullPath = Path.GetFullPath(@"\dir1\dir2\file.ext");
+            Assert.AreEqual(@"\dir1\dir2\file.ext", fullPath);
          }
 
         [TestMethod]
         public void GetFullPath2()
         {
-            string fullPath = Path.GetFullPath(RootDirectory + @"\dir1\..\dir2\file.ext");
-            Assert.AreEqual(RootDirectory + @"\dir1\dir2\file.ext", fullPath);
+            string fullPath = Path.GetFullPath(@"\dir1\..\dir2\file.ext");
+            Assert.AreEqual(@"\dir1\..\dir2\file.ext", fullPath);
         }
 
         [TestMethod]

--- a/System.IO.FileSystem/Path.cs
+++ b/System.IO.FileSystem/Path.cs
@@ -114,20 +114,22 @@ namespace System.IO
                 throw new ArgumentNullException();
             }
 
-            return CombineInternal(path1, path2);
-        }
-
-        private static string CombineInternal(string first, string second)
-        {
-            ValidateNullOrEmpty(first);
-            ValidateNullOrEmpty(second);
-
-            if (IsPathRooted(second))
+            if (string.IsNullOrEmpty(path1))
             {
-                return second;
+                return path2;
             }
 
-            return JoinInternal(first, second);
+            if (string.IsNullOrEmpty(path2))
+            {
+                return path1;
+            }
+
+            if (IsPathRooted(path2))
+            {
+                return path2;
+            }
+
+            return JoinInternal(path1, path2);
         }
 
         /// <summary>
@@ -186,7 +188,10 @@ namespace System.IO
         [return: NotNullIfNotNull("path")]
         public static string GetExtension(string path)
         {
-            ValidateNullOrEmpty(path);
+            if (path is null)
+            {
+                return null;
+            }
 
             var length = path.Length;
 
@@ -225,7 +230,10 @@ namespace System.IO
         [return: NotNullIfNotNull("path")]
         public static string GetFileName(string path)
         {
-            ValidateNullOrEmpty(path);
+            if (path is null)
+            {
+                return null;
+            }
 
             var root = GetPathRoot(path).Length;
 
@@ -251,7 +259,10 @@ namespace System.IO
         [return: NotNullIfNotNull("path")]
         public static string GetFileNameWithoutExtension(string path)
         {
-            ValidateNullOrEmpty(path);
+            if (path is null)
+            {
+                return null;
+            }
 
             var fileName = GetFileName(path);
             var lastPeriod = fileName.LastIndexOf('.');
@@ -392,6 +403,11 @@ namespace System.IO
 
             var hasSeparator = PathInternal.IsDirectorySeparator(first[first.Length - 1])
                                || PathInternal.IsDirectorySeparator(second[0]);
+
+            if (first.Equals(PathInternal.DirectorySeparatorCharAsString))
+            {
+                first = string.Empty;
+            }
 
             return hasSeparator ?
                 string.Concat(first, second) :


### PR DESCRIPTION
## Description
- Some wrongly added in #96.
- Add more processing of path edge cases.
- Fix several unit tests.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests.
- Comparing with full .NET. See output [here](https://dotnetfiddle.net/Skp2H7)

## Screenshots<!-- (IF APPROPRIATE): -->
![image](https://github.com/nanoframework/System.IO.FileSystem/assets/1881520/c4e39b59-4c3d-40a5-9ed7-a9ce80e03315)


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
