### PR TITLE
Fix Path.GetFullPath()

### DIFF
--- a/System.IO.FileSystem.UnitTests/PathUnitTests.cs
+++ b/System.IO.FileSystem.UnitTests/PathUnitTests.cs
@@ -1,4 +1,8 @@
-﻿using nanoFramework.TestFramework;
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+
+using nanoFramework.TestFramework;
 
 namespace System.IO.FileSystem.UnitTests
 {
@@ -103,7 +107,7 @@ namespace System.IO.FileSystem.UnitTests
         [TestMethod]
         public void GetDirectoryName_returns_directory()
         {
-            var tests = new[] { @"I:\directory", @"I:\directory\", @"I:\directory\file.ext"  };
+            var tests = new[] { @"I:\directory", @"I:\directory\", @"I:\directory\file.ext" };
             var answers = new[] { @"I:\", @"I:\directory", @"I:\directory" };
 
             for (var i = 0; i < tests.Length; i++)
@@ -311,26 +315,27 @@ namespace System.IO.FileSystem.UnitTests
             }
         }
 
+        [DataRow(@"\dir1\dir2\file.ext")]
+        [DataRow(@"\dir1\dir2\file.ext")]
+        [DataRow(@"\dir1\..\dir2\file.ext")]
+        [DataRow(@"\dir1\..\dir2\..\dir3\file.ext")]
         [TestMethod]
-        public void GetFullPath0()
+        public void GetFullPathWithFiles(string pathToTest)
         {
-            string fullPath = Path.GetFullPath(@"dir1\dir2\file.ext");
+            string fullPath = Path.GetFullPath(pathToTest);
+            Assert.AreEqual(pathToTest, fullPath);
+        }
 
-            Assert.AreEqual(@"\dir1\dir2\file.ext", fullPath);
-         }
-
+        [DataRow(@"\dir1\..\..\dir2\", @"\dir1\..\..\dir2\")]
+        [DataRow(@"\dir1\..\..\dir2", @"\dir1\..\..\dir2")]
+        [DataRow(@"dir1\dir2\", @"dir1\dir2\")]
+        [DataRow(@"dir1\dir2", @"dir1\dir2")]
+        [DataRow(@"\dir1\dir2\", @"\dir1\dir2\")]
         [TestMethod]
-        public void GetFullPath1()
+        public void GetFullPathWithDirectories(string pathToTest, string expectedPath)
         {
-            string fullPath = Path.GetFullPath(@"\dir1\dir2\file.ext");
-            Assert.AreEqual(@"\dir1\dir2\file.ext", fullPath);
-         }
-
-        [TestMethod]
-        public void GetFullPath2()
-        {
-            string fullPath = Path.GetFullPath(@"\dir1\..\dir2\file.ext");
-            Assert.AreEqual(@"\dir1\..\dir2\file.ext", fullPath);
+            string fullPath = Path.GetFullPath(pathToTest);
+            Assert.AreEqual(expectedPath, fullPath);
         }
 
         [TestMethod]
@@ -398,7 +403,7 @@ namespace System.IO.FileSystem.UnitTests
         {
             var tests = new[]
             {
-                @"\", "/", "I:", @"I:\", @"I:\file.ext", @"I:\directory\file.ext" 
+                @"\", "/", "I:", @"I:\", @"I:\file.ext", @"I:\directory\file.ext"
             };
 
             for (var i = 0; i < tests.Length; i++)

--- a/System.IO.FileSystem/Path.cs
+++ b/System.IO.FileSystem/Path.cs
@@ -288,9 +288,7 @@ namespace System.IO
                 // path = Combine(currDir, path);
             }
 
-            return Combine(
-                GetDirectoryName(path),
-                GetFileName(path));
+            return PathInternal.NormalizeDirectorySeparators(path);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Now returns a properly formatted path.

## Motivation and Context


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Add new Unit tests and improved existing ones related with `GetFullPath()`.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
